### PR TITLE
Added client side index view for all recipes

### DIFF
--- a/CookBook/client/src/components/ApplicationViews.js
+++ b/CookBook/client/src/components/ApplicationViews.js
@@ -3,6 +3,7 @@ import { Switch, Route, Redirect } from "react-router-dom";
 import Login from "./Login";
 import Register from "./Register";
 import Homepage from "./Homepage";
+import RecipeList from "./Recipes/RecipeList";
 
 export default function ApplicationViews({ isLoggedIn }) {
   return (
@@ -11,6 +12,10 @@ export default function ApplicationViews({ isLoggedIn }) {
 
         <Route path="/" exact>
           {isLoggedIn ? <Homepage /> : <Redirect to="/login" />}
+        </Route>
+
+        <Route path="/recipes" exact>
+        {isLoggedIn ? <RecipeList /> : <Redirect to="/login" />}
         </Route>
 
         <Route path="/login">

--- a/CookBook/client/src/components/Recipes/Recipe.js
+++ b/CookBook/client/src/components/Recipes/Recipe.js
@@ -1,0 +1,19 @@
+import React from "react";
+import { Card, CardBody, CardTitle, CardText } from "reactstrap";
+
+const Recipe = ({ recipe }) => {
+    return (
+        <Card>
+            <CardBody>
+                <CardTitle tag="h1">
+                    {recipe.name}
+                </CardTitle>
+                <CardText>
+                    {recipe.description}
+                </CardText>
+            </CardBody>
+        </Card>
+    );
+};
+
+export default Recipe;

--- a/CookBook/client/src/components/Recipes/RecipeList.js
+++ b/CookBook/client/src/components/Recipes/RecipeList.js
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from "react";
+import Recipe from "./Recipe";
+import { getAllRecipes } from "../../modules/recipeManager";
+import { ListGroup, ListGroupItem } from "reactstrap";
+import { Link } from "react-router-dom";
+
+const RecipeList = () => {
+    const [recipes, setRecipes] = useState([]);
+  
+    const getRecipes = () => {
+      getAllRecipes().then((recipes) => setRecipes(recipes));
+    };
+  
+    useEffect(() => {
+      getRecipes();
+    }, []);
+  
+    return (
+      <div className="container">
+        <div className="row justify-content-center">
+          <ListGroup>
+            {recipes.map((recipe) => {
+              return (
+                <ListGroupItem key={recipe.id}>
+                  <Recipe recipe={recipe} />
+                  <Link to={`/recipes/${recipe.id}`}>Details</Link>
+                </ListGroupItem>
+              );
+            })}
+          </ListGroup>
+        </div>
+      </div>
+    );
+  };
+  
+  export default RecipeList;

--- a/CookBook/client/src/modules/recipeManager.js
+++ b/CookBook/client/src/modules/recipeManager.js
@@ -1,0 +1,20 @@
+import { getToken } from "./authManager";
+
+const _apiUrl = "/api/Recipe";
+
+export const getAllRecipes = () => {
+  return getToken().then((token) => {
+    return fetch(_apiUrl, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    }).then((resp) => {
+      if (resp.ok) {
+        return resp.json();
+      } else {
+        throw new Error("An error occurred retrieving recipes");
+      }
+    });
+  });
+};


### PR DESCRIPTION
#### Changes Made
1. Added a Recipe manager, list, and child component to the client side so the user can view a list of all recipes
​
#### Steps to Review
1. Checkout this branch locally.
    ```
    git fetch --all
    git checkout jf-recipesView
    ```
2. Open a new Terminal tab (⌘T) and navigate to the server directory.
3. Test app functionality.
    > Instructions for how reviewer can test functionality, and detailed description of what the expected outcome is.
    > Example: When user does BLANK, then BLANK should happen.
4. View code file.
    > Confirm file modifications are present as indicated above.
    > Confirm no unused code or extraneous comments exist.
